### PR TITLE
Feat: aop를 이용한 jwt 토큰 payload 파싱 후 fetcher인자로 전달

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //DGS

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     //DGS
     implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
     implementation "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+    implementation("com.netflix.graphql.dgs:graphql-dgs-extended-scalars")
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/palette/PaletteApplication.java
+++ b/src/main/java/com/palette/PaletteApplication.java
@@ -2,10 +2,12 @@ package com.palette;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class PaletteApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/palette/aop/LoginUserAspect.java
+++ b/src/main/java/com/palette/aop/LoginUserAspect.java
@@ -1,0 +1,39 @@
+package com.palette.aop;
+
+import com.palette.infra.jwtTokenProvider.JwtTokenProvider;
+import com.palette.infra.jwtTokenProvider.JwtTokenType;
+import com.palette.resolver.LoginUser;
+import com.palette.utils.AuthorizationExtractor;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LoginUserAspect {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Around("@annotation(com.palette.resolver.Authentication)")
+    public Object test(ProceedingJoinPoint pjp) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String token = AuthorizationExtractor.extract(request);
+
+        Object[] args = pjp.getArgs();
+        Object inputArgument = args[0];
+
+        String email = jwtTokenProvider.getEmailFromPayLoad(token, JwtTokenType.ACCESS_TOKEN);
+        LoginUser loginUser = new LoginUser(email);
+        Object resultObj = pjp.proceed(new Object[]{inputArgument, loginUser});
+        return resultObj;
+    }
+
+}

--- a/src/main/java/com/palette/color/fetcher/ColorFetcher.java
+++ b/src/main/java/com/palette/color/fetcher/ColorFetcher.java
@@ -21,8 +21,8 @@ public class ColorFetcher {
 
     private final ColorRepository colorRepository;
 
-    @DgsQuery
-    public List<ReadColorOutput> color() {
+    @DgsQuery(field = "color")
+    public List<ReadColorOutput> findColor() {
         List<Color> colors = colorRepository.findAll(Sort.by(Direction.ASC, "order"));
         return colors.stream()
             .map(color -> ReadColorOutput.builder()

--- a/src/main/java/com/palette/diary/fetcher/DiaryFetcher.java
+++ b/src/main/java/com/palette/diary/fetcher/DiaryFetcher.java
@@ -4,10 +4,14 @@ import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsMutation;
 import com.netflix.graphql.dgs.InputArgument;
 import com.palette.diary.domain.Diary;
+import com.palette.diary.domain.DiaryGroup;
 import com.palette.diary.fetcher.dto.CreateDiaryInput;
 import com.palette.diary.fetcher.dto.CreateDiaryOutput;
+import com.palette.diary.fetcher.dto.InviteDiaryInput;
+import com.palette.diary.fetcher.dto.InviteDiaryOutput;
 import com.palette.diary.repository.DiaryGroupRepository;
 import com.palette.diary.repository.DiaryRepository;
+import com.palette.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -16,18 +20,36 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @DgsComponent
 @RequiredArgsConstructor
+@Transactional
 public class DiaryFetcher {
 
     private final DiaryRepository diaryRepository;
     private final DiaryGroupRepository diaryGroupRepository;
 
     @DgsMutation
-    @Transactional
     public CreateDiaryOutput createDiary(@InputArgument CreateDiaryInput createDiaryInput) {
         String invitationCode = RandomStringUtils.randomAlphabetic(8);
         Diary diary = diaryRepository.save(createDiaryInput.toEntity(invitationCode));
         diaryGroupRepository.save(createDiaryInput.toEntity(diary));
-        return CreateDiaryOutput.toCreateDto(diary.getInvitationCode());
+        return CreateDiaryOutput.of(diary.getInvitationCode());
+    }
+
+    @DgsMutation
+    public InviteDiaryOutput inviteDiary(@InputArgument InviteDiaryInput inviteDiaryInput) {
+        //TODO: join 사용하여 쿼리 한번으로 축소 가능성 검토
+        Diary diary = diaryRepository.findByInvitationCode(inviteDiaryInput.getInvitationCode())
+            .orElseThrow(() -> new IllegalArgumentException()); //TODO: 예외처리
+
+        DiaryGroup diaryGroup = diaryGroupRepository.findByDiaryAndIsAdmin(diary, 1)
+            .orElseThrow(() -> new IllegalArgumentException());//TODO: 예외처리;
+
+        User adminUser = diaryGroup.getUser();
+
+        //TODO: 토큰 파싱 후 추출한 데이터로 User객체 생성 후 인자로 전달
+        //현재는 일기를 생성한 유저 객체 삽입
+        diaryGroupRepository.save(InviteDiaryInput.of(adminUser, diary));
+
+        return InviteDiaryOutput.of("nickname", diary.getTitle());
     }
 
 }

--- a/src/main/java/com/palette/diary/fetcher/dto/CreateDiaryInput.java
+++ b/src/main/java/com/palette/diary/fetcher/dto/CreateDiaryInput.java
@@ -27,9 +27,8 @@ public class CreateDiaryInput {
     public DiaryGroup toEntity(Diary diary) {
         return DiaryGroup.builder()
             .user(User.builder()
-                .id(1L)
-                .email("wlsgmdchemd@naver.com")
-                .socialTypes(List.of(SocialType.KAKAO))
+                .email("test@gmail.com")
+                .socialTypes(List.of(SocialType.NAVER))
                 .build()
             )
             .diary(diary)

--- a/src/main/java/com/palette/diary/fetcher/dto/CreateDiaryInput.java
+++ b/src/main/java/com/palette/diary/fetcher/dto/CreateDiaryInput.java
@@ -2,9 +2,7 @@ package com.palette.diary.fetcher.dto;
 
 import com.palette.diary.domain.Diary;
 import com.palette.diary.domain.DiaryGroup;
-import com.palette.user.domain.SocialType;
 import com.palette.user.domain.User;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,14 +21,9 @@ public class CreateDiaryInput {
             .build();
     }
 
-    //TODO: 토큰 파싱 후 추출한 데이터로 User객체 생성 후 인자로 전달
-    public DiaryGroup toEntity(Diary diary) {
+    public DiaryGroup toEntity(Diary diary, User user) {
         return DiaryGroup.builder()
-            .user(User.builder()
-                .email("test@gmail.com")
-                .socialTypes(List.of(SocialType.NAVER))
-                .build()
-            )
+            .user(user)
             .diary(diary)
             .isAdmin(1)
             .build();

--- a/src/main/java/com/palette/diary/fetcher/dto/CreateDiaryOutput.java
+++ b/src/main/java/com/palette/diary/fetcher/dto/CreateDiaryOutput.java
@@ -13,7 +13,7 @@ public class CreateDiaryOutput {
     private String color;
     private String invitationCode;
 
-    public static CreateDiaryOutput toCreateDto(String invitationCode) {
+    public static CreateDiaryOutput of(String invitationCode) {
         return CreateDiaryOutput.builder()
             .invitationCode(invitationCode)
             .build();

--- a/src/main/java/com/palette/diary/fetcher/dto/InviteDiaryInput.java
+++ b/src/main/java/com/palette/diary/fetcher/dto/InviteDiaryInput.java
@@ -1,0 +1,23 @@
+package com.palette.diary.fetcher.dto;
+
+import com.palette.diary.domain.Diary;
+import com.palette.diary.domain.DiaryGroup;
+import com.palette.user.domain.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InviteDiaryInput {
+
+    private String invitationCode;
+
+    public static DiaryGroup of(User user, Diary diary) {
+        return DiaryGroup.builder()
+            .user(user)
+            .diary(diary)
+            .isAdmin(0)
+            .build();
+    }
+
+}

--- a/src/main/java/com/palette/diary/fetcher/dto/InviteDiaryOutput.java
+++ b/src/main/java/com/palette/diary/fetcher/dto/InviteDiaryOutput.java
@@ -1,0 +1,22 @@
+package com.palette.diary.fetcher.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class InviteDiaryOutput {
+
+    private String nickname;
+    private String title;
+
+    public static InviteDiaryOutput of(String nickname, String title) {
+        return InviteDiaryOutput.builder()
+            .nickname("닉네임") //TODO: User 엔티티 필드 추가 후 수정
+            .title(title)
+            .build();
+    }
+
+}

--- a/src/main/java/com/palette/diary/repository/DiaryGroupRepository.java
+++ b/src/main/java/com/palette/diary/repository/DiaryGroupRepository.java
@@ -1,8 +1,11 @@
 package com.palette.diary.repository;
 
+import com.palette.diary.domain.Diary;
 import com.palette.diary.domain.DiaryGroup;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryGroupRepository extends JpaRepository<DiaryGroup, Long> {
 
+    Optional<DiaryGroup> findByDiaryAndIsAdmin(Diary diary, Integer isAdmin);
 }

--- a/src/main/java/com/palette/diary/repository/DiaryGroupRepository.java
+++ b/src/main/java/com/palette/diary/repository/DiaryGroupRepository.java
@@ -2,10 +2,12 @@ package com.palette.diary.repository;
 
 import com.palette.diary.domain.Diary;
 import com.palette.diary.domain.DiaryGroup;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DiaryGroupRepository extends JpaRepository<DiaryGroup, Long> {
+    Optional<DiaryGroup> findByUserId(String userId);
 
     Optional<DiaryGroup> findByDiaryAndIsAdmin(Diary diary, Integer isAdmin);
 }

--- a/src/main/java/com/palette/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/palette/diary/repository/DiaryRepository.java
@@ -1,10 +1,20 @@
 package com.palette.diary.repository;
 
 import com.palette.diary.domain.Diary;
+import com.palette.user.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    @Query("SELECT d FROM DiaryGroup g " +
+            "RIGHT JOIN Diary d ON g.diary = d.id " +
+            "WHERE g.user = :user"
+    )
+    public List<Diary> findUserDiaries(@Param("user") User user);
 
     Optional<Diary> findByInvitationCode(String invitationCode);
 }

--- a/src/main/java/com/palette/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/palette/diary/repository/DiaryRepository.java
@@ -1,8 +1,10 @@
 package com.palette.diary.repository;
 
 import com.palette.diary.domain.Diary;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
+    Optional<Diary> findByInvitationCode(String invitationCode);
 }

--- a/src/main/java/com/palette/resolver/Authentication.java
+++ b/src/main/java/com/palette/resolver/Authentication.java
@@ -1,0 +1,12 @@
+package com.palette.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Authentication {
+
+}

--- a/src/main/java/com/palette/resolver/LoginUser.java
+++ b/src/main/java/com/palette/resolver/LoginUser.java
@@ -1,0 +1,15 @@
+package com.palette.resolver;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginUser {
+
+    private String email;
+}

--- a/src/main/java/com/palette/user/UserController.java
+++ b/src/main/java/com/palette/user/UserController.java
@@ -1,10 +1,9 @@
 package com.palette.user;
 
 import com.palette.infra.jwtTokenProvider.JwtRefreshTokenInfo;
-import com.palette.infra.jwtTokenProvider.JwtTokenInfo;
 import com.palette.infra.jwtTokenProvider.JwtTokenType;
-import com.palette.user.dto.LoginRequest;
-import com.palette.user.dto.TokenResponse;
+import com.palette.user.fetcher.dto.LoginRequest;
+import com.palette.user.fetcher.dto.TokenResponse;
 import com.palette.user.service.UserService;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/palette/user/domain/User.java
+++ b/src/main/java/com/palette/user/domain/User.java
@@ -1,15 +1,20 @@
 package com.palette.user.domain;
 
 import com.palette.BaseEntity;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.palette.diary.domain.DiaryGroup;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.Collection;
+import java.util.Set;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @Entity
 public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
@@ -21,12 +26,12 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Collection<SocialType> socialTypes;
 
-    @Builder
-    public User(Long id, String email, Collection<SocialType> socialTypes) {
-        this.id = id;
-        this.email = email;
-        this.socialTypes = socialTypes;
-    }
+    @Column(name = "profile_img", nullable = true)
+    private String profileImg = null;
+
+    @Builder.Default
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
 
     public boolean addSocialType(SocialType socialType) {
         if (this.socialTypes.contains(socialType)) {

--- a/src/main/java/com/palette/user/fetcher/UserFetcher.java
+++ b/src/main/java/com/palette/user/fetcher/UserFetcher.java
@@ -1,0 +1,38 @@
+package com.palette.user.fetcher;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.palette.diary.domain.Diary;
+import com.palette.diary.repository.DiaryGroupRepository;
+import com.palette.diary.repository.DiaryRepository;
+import com.palette.user.domain.User;
+import com.palette.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@DgsComponent
+@RequiredArgsConstructor
+public class UserFetcher {
+    private final UserRepository userRepository;
+    private final DiaryGroupRepository diaryGroupRepository;
+    private final DiaryRepository diaryRepository;
+    private final EntityManager entityManager;
+
+    @DgsQuery(field = "myProfile")
+    private User getMyProfile() { // TODO: AuthUser의 email 받아오기
+        return userRepository.findByEmail("test@gmail.com").orElseThrow(); // TODO: UserNotFoundException
+    }
+
+    @DgsData(parentType = "User", field = "diaries")
+    private List<Diary> getUserDiaries(DgsDataFetchingEnvironment dfe) {
+        User user = dfe.getSource();
+        return diaryRepository.findUserDiaries(user);
+    }
+}

--- a/src/main/java/com/palette/user/fetcher/dto/LoginRequest.java
+++ b/src/main/java/com/palette/user/fetcher/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.palette.user.dto;
+package com.palette.user.fetcher.dto;
 
 import com.palette.user.domain.SocialType;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/palette/user/fetcher/dto/TokenResponse.java
+++ b/src/main/java/com/palette/user/fetcher/dto/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.palette.user.dto;
+package com.palette.user.fetcher.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/palette/user/service/UserService.java
+++ b/src/main/java/com/palette/user/service/UserService.java
@@ -7,14 +7,12 @@ import com.palette.token.domain.RefreshToken;
 import com.palette.token.repository.RefreshTokenRepository;
 import com.palette.user.domain.SocialType;
 import com.palette.user.domain.User;
-import com.palette.user.dto.LoginRequest;
-import com.palette.user.dto.TokenResponse;
+import com.palette.user.fetcher.dto.LoginRequest;
+import com.palette.user.fetcher.dto.TokenResponse;
 import com.palette.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
 
 import javax.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/palette/utils/AuthorizationExtractor.java
+++ b/src/main/java/com/palette/utils/AuthorizationExtractor.java
@@ -1,0 +1,34 @@
+package com.palette.utils;
+
+import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
+
+public class AuthorizationExtractor {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String ACCESS_TOKEN_TYPE =
+        AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
+    private static final String BEARER_TYPE = "Bearer";
+
+    private AuthorizationExtractor() {
+    }
+
+    public static String extract(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if ((value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase()))) {
+                String authHeaderValue = value.substring(BEARER_TYPE.length()).trim();
+                String token = value.substring(0, BEARER_TYPE.length()).trim();
+                request.setAttribute(ACCESS_TOKEN_TYPE, token);
+                int commaIndex = authHeaderValue.indexOf(',');
+                if (commaIndex > 0) {
+                    authHeaderValue = authHeaderValue.substring(0, commaIndex);
+                }
+                return authHeaderValue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/schema/color.graphqls
+++ b/src/main/resources/schema/color.graphqls
@@ -1,4 +1,4 @@
-type Query {
+extend type Query {
     color: [ReadColorOutput]
 }
 

--- a/src/main/resources/schema/common.graphql
+++ b/src/main/resources/schema/common.graphql
@@ -1,0 +1,2 @@
+type Query {}
+type Mutation {}

--- a/src/main/resources/schema/diary.graphqls
+++ b/src/main/resources/schema/diary.graphqls
@@ -1,5 +1,11 @@
 type Mutation {
     createDiary(createDiaryInput: CreateDiaryInput): CreateDiaryOutput
+    inviteDiary(inviteDiaryInput: InviteDiaryInput): InviteDiaryOutput
+}
+
+input CreateDiaryInput {
+    title: String!
+    color: String!
 }
 
 type CreateDiaryOutput{
@@ -8,7 +14,11 @@ type CreateDiaryOutput{
     color: String
 }
 
-input CreateDiaryInput {
-    title: String!
-    color: String!
+input InviteDiaryInput {
+    invitationCode: String!
+}
+
+type InviteDiaryOutput{
+    nickname: String
+    title: String
 }

--- a/src/main/resources/schema/diary.graphqls
+++ b/src/main/resources/schema/diary.graphqls
@@ -1,4 +1,12 @@
-type Mutation {
+type Diary {
+    title: String!
+    invitationCode: String!
+    color: String
+    users: [User]
+    isDeleted:Boolean
+}
+
+extend type Mutation {
     createDiary(createDiaryInput: CreateDiaryInput): CreateDiaryOutput
     inviteDiary(inviteDiaryInput: InviteDiaryInput): InviteDiaryOutput
 }

--- a/src/main/resources/schema/user.graphql
+++ b/src/main/resources/schema/user.graphql
@@ -1,0 +1,16 @@
+scalar LocalTime
+
+type User {
+    id: Int!
+    email: String!
+    nickname: String!
+    profileImg: String
+    diaries: [Diary]!
+    isDeleted: Boolean!
+    createdAt: LocalTime!
+    updatedAt: LocalTime!
+}
+
+extend type Query {
+    myProfile: User
+}

--- a/src/main/resources/schema/user.graphql
+++ b/src/main/resources/schema/user.graphql
@@ -3,7 +3,7 @@ scalar LocalTime
 type User {
     id: Int!
     email: String!
-    nickname: String!
+    nickname: String
     profileImg: String
     diaries: [Diary]!
     isDeleted: Boolean!


### PR DESCRIPTION
- aop를 이용해서 토큰파싱 후 LoginUser 객체를 생성해서 graphql 호출 시 필요한 메소드의 인자로 받을 수 있도록 추가했습니다.
- 제한사항은 graphql과 관련된 request 객체인데 반드시 메소드이 첫번째 인자로 위치해야 aop가 정상 작동하는 사항입니다.
- aop 코드 일부
```
        Object[] args = pjp.getArgs();
        Object inputArgument = args[0];
        
        //...
        
        Object resultObj = pjp.proceed(new Object[]{inputArgument, loginUser});
        return resultObj;
```
- 사용법은 DiaryFetcher클래스의 createDiary메소드 참고하시면 됩니다.

- 일기 생성 시 DiaryGroup 엔티티도 생성하는데 User 객체를 정적 데이터가 아닌 db에서 조회할 수 있도록 같이 수정했습니다.

